### PR TITLE
fix scheme and versioning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,8 +22,7 @@ var getApiDescription = module.exports.getApiDescription = function(path) {
 };
 
 var defaultOptions = {
-    discoveryUrl: module.exports.swaggerPathPrefix+'resources.json',
-    version: '1.0'
+    discoveryUrl: module.exports.swaggerPathPrefix+'resources.json'
 };
 
 var convertToSwagger = module.exports._convertToSwagger = function (path) {

--- a/lib/swagger-doc.js
+++ b/lib/swagger-doc.js
@@ -90,7 +90,7 @@ swagger.configure = function(server, options) {
         self = this;
 
     this.server = server;
-    this.apiVersion = options.version || this.server.version || '0.1';
+    this.apiVersion = options.version || this.server.versions || '1.0.0';
     this.basePath = options.basePath;
     this.info = options.info;
 
@@ -125,7 +125,7 @@ swagger.createResource = function(path, options) {
 };
 
 swagger._createResponse = function(req) {
-    var basePath = this.basePath || 'http://' + req.headers.host;
+    var basePath = this.basePath || '//' + req.headers.host;
     return {
         swaggerVersion: SWAGGER_VERSION,
         apiVersion: this.apiVersion,


### PR DESCRIPTION
Swagger basePath was breaking on https

Also, the version set on the restify server was not being passed through (apparently the property name is server_s_)

``` coffeescript
pkg = require './package'

module.exports.server = server = restify.createServer
    name: pkg.name
    version: pkg.version

restifySwagger.configure server # versioning breaks without ,{version: pkg.version}
```
