### PR TITLE
added headers to swagger-doc responses to work cleanly with swagger-ui.

### DIFF
--- a/lib/swagger-doc.js
+++ b/lib/swagger-doc.js
@@ -97,6 +97,9 @@ swagger.configure = function(server, options) {
     this.server.get(discoveryUrl, function(req, res) {
         var result = self._createResponse(req);
         result.apis = self.resources.map(function(r) { return {path: r.path, description: r.description || '' }; });
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+        res.header("Access-Control-Allow-Headers", "Content-Type");
         res.send(result);
     });
 };
@@ -117,7 +120,9 @@ swagger.createResource = function(path, options) {
         result.resourcePath = path;
         result.apis = Object.keys(resource.apis).map(function(k) { return resource.apis[k]; });
         result.models = resource.models;
-
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+        res.header("Access-Control-Allow-Headers", "Content-Type");
         res.send(result);
     });
 


### PR DESCRIPTION
Default swagger-ui constantly gives "Can't access server" errors when the "Access-Control-Allow-Origin" is not set.
