### PR TITLE
fix swagger var scope problem

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,8 +119,8 @@ module.exports.loadRestifyRoutes = function () {
             var url = spec.url || item.path;
             var name = lingo.camelcase(url.replace(/[\/_]/g, ' '));
             var method = spec.method;
-            var swagger = spec.swagger || {};
-            var mySwaggerPathParts = swagger.docPath || url.split(path.sep)[1];
+            var specSwagger = spec.swagger || {};
+            var mySwaggerPathParts = specSwagger.docPath || url.split(path.sep)[1];
             var mySwaggerPath = module.exports.swaggerPathPrefix + mySwaggerPathParts;
             var models = spec.models || {};
 
@@ -200,17 +200,17 @@ module.exports.loadRestifyRoutes = function () {
                         paramType: 'body'
                     });
                 }
-                swaggerDoc[method.toLowerCase()](convertToSwagger(url), swagger.summary, {
-                    notes: swagger.notes || null,
-                    nickname: swagger.nickname || name,
-                    responseClass: swagger.responseClass || undefined,
-                    produces: swagger.produces || [
+                swaggerDoc[method.toLowerCase()](convertToSwagger(url), specSwagger.summary, {
+                    notes: specSwagger.notes || null,
+                    nickname: specSwagger.nickname || name,
+                    responseClass: specSwagger.responseClass || undefined,
+                    produces: specSwagger.produces || swagger.produces || [
                         'application/json'
                     ],
-                    consumes: swagger.consumes || [
+                    consumes: specSwagger.consumes || swagger.consumes || [
                         'application/json'
                     ],
-                    responseMessages: swagger.responseMessages || [
+                    responseMessages: specSwagger.responseMessages || swagger.responseMessages || [
                         {
                             code: 500,
                             message: 'Internal Server Error'

--- a/lib/swagger-doc.js
+++ b/lib/swagger-doc.js
@@ -93,6 +93,7 @@ swagger.configure = function(server, options) {
     this.apiVersion = options.version || this.server.versions || '1.0.0';
     this.basePath = options.basePath;
     this.info = options.info;
+    this.responseMessages = options.responseMessages;
 
     this.server.get(discoveryUrl, function(req, res) {
         var result = self._createResponse(req);


### PR DESCRIPTION
`var swagger` was defined twice and causing scoping issues. This adds the ability to pass in "responseMessages" during configuration.
