### PR TITLE
Add authorizations property to route definition and support for third party authorizations plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,90 @@ node-restify-swagger
 [![Coverage Status](https://coveralls.io/repos/z0mt3c/node-restify-swagger/badge.png?branch=master)](https://coveralls.io/r/z0mt3c/node-restify-swagger?branch=master)
 [![Dependency Status](https://gemnasium.com/z0mt3c/node-restify-swagger.png)](https://gemnasium.com/z0mt3c/node-restify-swagger)
 
+Swagger resource generation for [Restify](https://github.com/mcavage/node-restify).
 
-Install
+Uses [node-restify-validation](https://github.com/z0mt3c/node-restify-validation) for query, path, body validations.
+
+Includes an optional access control scheme which allows api methods to be hidden and access granted from main application.
+
+
+Installation
 -------
 
+Install the module.
+
     npm install node-restify-swagger
-    
+
+Include a copy of [Swagger-UI](https://github.com/swagger-api/swagger-ui) at the root of your project.
+
+
+Demo project
+-------
+
+A simple demo project can be cloned from [node-restify-demo](https://github.com/z0mt3c/node-restify-demo).
+
+
+Sample App.js
+-------
+ 
+    var restify = require('restify');
+	var restifyValidation = require('node-restify-validation');
+	var restifySwagger = require('node-restify-swagger');
+
+	var server = module.exports.server = restify.createServer();
+	server.use(restify.queryParser());
+	server.use(restify.bodyParser());
+	server.use(restifyValidation.validationPlugin({ errorsAsArray: false }));
+
+	restifySwagger.configure(server, {
+	    info: {
+	        contact: 'email@domain.tld',
+	        description: 'Description text',
+	        license: 'MIT',
+	        licenseUrl: 'http://opensource.org/licenses/MIT',
+	        termsOfServiceUrl: 'http://opensource.org/licenses/MIT',
+	        title: 'Node Restify Swagger Demo'
+	    },
+	    apiDescriptions: {
+	        'get':'GET-Api Resourcen'
+	    }
+	});
+
+	// Test Controller
+	server.get({url: '/get/:name',
+        authorizations: 'public',
+	    swagger: {
+	        summary: 'My hello call description',
+	        notes: 'My hello call notes',
+	        nickname: 'sayHelloCall'
+	    },
+	    validation: {
+	        name: { isRequired: true, isIn: ['foo', 'bar'], scope: 'path', description: 'Your unreal name' },
+	        status: { isRequired: true, isIn: ['foo', 'bar'], scope: 'query', description: 'Are you foo or bar?' },
+	        email: { isRequired: false, isEmail: true, scope: 'query', description: 'Your real email address' },
+	        age: { isRequired: true, isInt: true, scope: 'query', description: 'Your age' },
+	        accept: { isRequired: true, isIn: ['true', 'false'], scope: 'query', swaggerType: 'boolean', description: 'Are you foo or bar?' },
+	        password: { isRequired: true, description: 'New password' },
+	        passwordRepeat: { equalTo: 'password', description: 'Repeated password'}
+	    }}, function (req, res, next) {
+	    res.send(req.params);
+	});
+
+	// Serve static swagger resources
+	server.get(/^\/docs\/?.*/, restify.serveStatic({directory: './swagger-ui'}));
+	server.get('/', function (req, res, next) {
+	    res.header('Location', '/docs/index.html');
+	    res.send(302);
+	    return next(false);
+	});
+
+	restifySwagger.loadRestifyRoutes();
+
+	// Start server
+	server.listen(8001, function () {
+	    console.log('%s listening at %s', server.name, server.url);
+	});
+
     
 License
 -------

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,6 +126,8 @@ module.exports.loadRestifyRoutes = function () {
             var mySwaggerPath = module.exports.swaggerPathPrefix + mySwaggerPathParts;
             var models = spec.models || {};
 
+            var authorizations = ((typeof spec.authorizations === 'string') ? { type: spec.authorizations } : {});
+
             if (!_.contains(self.options.blacklist, mySwaggerPathParts)) {
                 var swaggerDoc = self.findOrCreateResource(mySwaggerPath, { models: models, description: getApiDescription(mySwaggerPath) });
                 var parameters = [];
@@ -231,7 +233,8 @@ module.exports.loadRestifyRoutes = function () {
                                 message: 'Internal Server Error'
                             }
                         ],
-                        parameters: parameters
+                        parameters: parameters,
+                        authorizations: authorizations
                     });
                     defined[spec.method+spec.url] = true;
                 }

--- a/lib/swagger-doc.js
+++ b/lib/swagger-doc.js
@@ -95,6 +95,8 @@ swagger.configure = function(server, options) {
     this.info = options.info;
     this.responseMessages = options.responseMessages;
 
+    this.authorizationsPlugin = options.authorizationsPlugin;
+
     this.server.get(discoveryUrl, function(req, res) {
         var result = self._createResponse(req);
         result.apis = self.resources.map(function(r) { return {path: r.path, description: r.description || '' }; });
@@ -119,8 +121,24 @@ swagger.createResource = function(path, options) {
     this.server.get(path, function(req, res) {
         var result = self._createResponse(req);
         result.resourcePath = path;
-        result.apis = Object.keys(resource.apis).map(function(k) { return resource.apis[k]; });
-        result.models = resource.models;
+
+        // if the authorizations plugin is configured
+        if (typeof swagger.authorizationsPlugin !== 'undefined') {
+
+            // use third-party authorizations plugin to populate result.apis and result.models
+            var auth = swagger.authorizationsPlugin.createResource(req, res, resource);
+            result.apis = auth.apis;
+            result.models = auth.models;
+
+        }
+        else {
+
+            // default behavior
+            result.apis = Object.keys(resource.apis).map(function(k) { return resource.apis[k]; });
+            result.models = resource.models;
+
+        }
+
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Methods', 'GET, PATCH, POST, DELETE, PUT');
         res.header('Access-Control-Allow-Headers', 'Content-Type');


### PR DESCRIPTION
This Pull Request addresses issue #11.  
# Usage / Implementation
- You can optionally add an ‘authorizations’ parameter to each route with a space separated list of route-authorizations (Example: "admin super-admin"). 
  
  ``` javascript
  server.get({url: '/test/method/:data',
     authorizations: 'account',
     swagger: {
       summary: 'Get',
       notes: '',
       nickname: 'getTest'
     },
     validation: {
       data: { isRequired: true, description: 'Data', swaggerType: 'string', scope: 'path' }
     }}, function(req, res, next) {
        res.send( { data : "get" });
     });
  ```
- The authorizations are listed in the swagger resources.json.
  
  ```
  "resourcePath": "/swagger/test",
  "apis": [
      {
          "path": "/test/method/{data}",
          "description": "",
          "operations": [
              {
                  "notes": null,
                  "nickname": "getTest",
                  "produces": [
                      "application/json"
                  ],
                  "consumes": [
                      "application/json"
                  ],
                  "responseMessages": [
                      {
                          "code": 500,
                          "message": "Internal Server Error"
                      }
                  ],
                  "parameters": [
                      {
                          "type": "string",
                          "dataType": "string",
                          "name": "data",
                          "description": "Data",
                          "required": true,
                          "paramType": "path"
                      }
                  ],
                  "authorizations": {
                      "type": "account"
                  },
                  "summary": "Get",
                  "httpMethod": "GET",
                  "method": "GET"
              }
          ]
      }
  ```
- when swagger loads it will optionally call a third party plugin to verify the api_key (if provided) and user authorizations.
- configuring the third party plugin is done by passing the 'authorizationsPlugin' in the configuration options.
  
  ```
  restifySwagger.configure(server, {
      info: {
          contact: 'email@domain.tld',
          description: 'Description text',
          license: 'MIT',
          licenseUrl: 'http://opensource.org/licenses/MIT',
          termsOfServiceUrl: 'http://opensource.org/licenses/MIT',
          title: 'Node Restify Swagger Demo'
      },
      apiDescriptions: {
          'get':'GET-Api Resourcen'
      },
              authorizationsPlugin: swaggerAuthorizations
  });
  ```
