### PR TITLE
Allow for creation of different models for resources with same url but different method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,163 @@ node-restify-swagger
 [![Coverage Status](https://coveralls.io/repos/z0mt3c/node-restify-swagger/badge.png?branch=master)](https://coveralls.io/r/z0mt3c/node-restify-swagger?branch=master)
 [![Dependency Status](https://gemnasium.com/z0mt3c/node-restify-swagger.png)](https://gemnasium.com/z0mt3c/node-restify-swagger)
 
+## Requirements
+This project depends on https://github.com/z0mt3c/node-restify-validation.
 
-Install
--------
+## Example
+
+    var restify = require('restify');
+    var restifySwagger = require('node-restify-swagger');
+    var restifyValidation = require('node-restify-validation');
+
+    var server = restify.createServer();
+    server.use(restify.queryParser());
+    server.use(restifyValidation.validationPlugin({
+        errorsAsArray: false,
+    }));
+    restifySwagger.configure(server, {
+        description: 'Description of my API',
+        title: 'Title of my API',
+        allowMethodInModelNames: true
+    });
+
+    server.post({
+        url: '/animals',
+        swagger: {
+                summary: 'Add animal',
+                docPath: 'zoo'
+        },
+        validation: {
+            name: { isRequired: true, isAlpha:true, scope: 'body' },
+            locations: { isRequired: true, type:'array', swaggerType: 'Location', scope: 'body' }
+        },
+        models: {
+            Location: {
+                id: 'Location',
+                properties: {
+                    name: { type: 'string' },
+                    continent: { type: 'string' }
+                }
+            },
+        }
+    }, function (req, res, next) {
+        res.send(req.params);
+    });
+
+    restifySwagger.loadRestifyRoutes();
+    server.listen(8001, function () {
+        console.log('%s listening at %s', server.name, server.url);
+    });
+
+
+Above will validate and accept at POST /animals:
+
+    {
+        "name": "Tiger",
+        "location": [
+            { "name": "India", continent: "Asia" },
+            { "name": "China", continent: "Asia" }
+        ]
+    }
+
+And produce swagger spec doc at http://localhost:8001/swagger/resources.json
+
+    {
+      "swaggerVersion": "1.2",
+      "apiVersion": [],
+      "basePath": "http://localhost:8001",
+      "apis": [
+        {
+          "path": "/swagger/zoo",
+          "description": ""
+        }
+      ]
+    }
+
+And endpoint documentation at http://localhost:8001/swagger/zoo
+
+    {
+      "swaggerVersion": "1.2",
+      "apiVersion": [],
+      "basePath": "http://localhost:8001",
+      "resourcePath": "/swagger/zoo",
+      "apis": [
+        {
+          "path": "/animals",
+          "description": "",
+          "operations": [
+            {
+              "notes": null,
+              "nickname": "Animals",
+              "produces": [
+                "application/json"
+              ],
+              "consumes": [
+                "application/json"
+              ],
+              "responseMessages": [
+                {
+                  "code": 500,
+                  "message": "Internal Server Error"
+                }
+              ],
+              "parameters": [
+                {
+                  "name": "Body",
+                  "required": true,
+                  "dataType": "POSTAnimals",
+                  "paramType": "body"
+                }
+              ],
+              "summary": "Add animal",
+              "httpMethod": "POST",
+              "method": "POST"
+            }
+          ]
+        }
+      ],
+      "models": {
+        "Location": {
+          "id": "Location",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "continent": {
+              "type": "string"
+            }
+          }
+        },
+        "POSTAnimals": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "dataType": "string",
+              "name": "name",
+              "required": true
+            },
+            "locations": {
+              "type": "array",
+              "dataType": "Location",
+              "name": "locations",
+              "items": {
+                "$ref": "Location"
+              },
+              "required": true
+            }
+          }
+        }
+      }
+    }
+
+
+## Install
 
     npm install node-restify-swagger
-    
-    
-License
--------
+
+
+## License
+
 
 The MIT License (MIT)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,6 +130,10 @@ module.exports.loadRestifyRoutes = function () {
                 var swaggerDoc = self.findOrCreateResource(mySwaggerPath, { models: models, description: getApiDescription(mySwaggerPath) });
                 var parameters = [];
                 var modelName = name;
+                // to allow generetion of unique models for request with same url but different method
+                if (self.options.allowMethodInModelNames) {
+                    modelName = method + name;
+                }
                 var model = { properties: { } };
 
                 var hasPathParameters = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-restify-swagger",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "Timo Behrmann"
   },

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -305,4 +305,54 @@ describe('test', function () {
 
         done();
     });
+    it('should allow same paths with different method names have different models', function (done) {
+        var server = restify.createServer();
+
+        // defining /model route where only one parameter is provided in validation
+        server.del({ url: '/model',
+            swagger: {
+                summary: 'summary',
+                notes: 'notes',
+                nickname: 'nickname',
+                responseClass: 'Model',
+            },
+            validation: {
+                id: { isRequired: true, isInteger: true, scope: 'body' }
+            }
+        }, function (req, res, next) {
+            // not called
+            false.should.be.ok;
+        });
+
+        // defining route with same path but different method - validation model is different
+        server.put({ url: '/model',
+            swagger: {
+                summary: 'summary',
+                notes: 'notes',
+                nickname: 'nickname',
+                responseClass: 'Model',
+            },
+            validation: {
+                foo: { isRequired: true, isBoolean:true, scope: 'body' },
+                bar: { isRequired: true, isBoolean:true, scope: 'body' }
+            }
+        }, function (req, res, next) {
+            // not called
+            false.should.be.ok;
+        });
+
+        index.configure(server, {
+            allowMethodInModelNames: true
+        });
+        index.loadRestifyRoutes();
+
+        //index.swagger.resources.length.should.equal(2);
+        var swaggerResource = index.swagger.resources[0];
+
+        Object.keys(swaggerResource.models).length.should.equal(2);
+        Object.keys(swaggerResource.models.DELETEModel.properties).length.should.equal(1);
+        Object.keys(swaggerResource.models.PUTModel.properties).length.should.equal(2);
+
+        done();
+    });
 });


### PR DESCRIPTION
Fix issue causing models getting overriden by model definitions from routes with same paths.

Introduced allowMethodInModelNames: true flag to enable this as it might be breaking change in some cases.

Here's the issue:

Create new resource with POST:
POST /animals - accepts: { name: "string", age: "integer" }

Update reasource with PUT, but only allow name to be updated:
PUT /animals - accepts: { name: "string" }

At the moment, POST Model which should have both name and age props will get overridden by PUT Model
because they use same "Animals" model.
